### PR TITLE
fix: E2EテストのplaceholderをUIリデザイン後の表記に修正

### DIFF
--- a/e2e/bodyRecord.spec.ts
+++ b/e2e/bodyRecord.spec.ts
@@ -14,13 +14,13 @@ test.describe.serial('体重記録 CRUD', () => {
     await page.getByRole('button', { name: '体重を記録' }).first().click();
 
     // 入力欄が表示されたことでモーダルが開いたと判断する
-    await expect(page.getByPlaceholder('75.0')).toBeVisible();
+    await expect(page.getByPlaceholder('体重 (kg) を入力')).toBeVisible();
 
-    await page.getByPlaceholder('75.0').fill(TEST_WEIGHT);
+    await page.getByPlaceholder('体重 (kg) を入力').fill(TEST_WEIGHT);
     await page.getByRole('button', { name: '保存' }).click();
 
     // モーダルが閉じたことを確認する
-    await expect(page.getByPlaceholder('75.0')).not.toBeVisible();
+    await expect(page.getByPlaceholder('体重 (kg) を入力')).not.toBeVisible();
 
     // revalidatePath後の再レンダリングで記録一覧に体重が表示されることを確認する
     await expect(page.getByText(`${TEST_WEIGHT} kg`)).toBeVisible();
@@ -33,7 +33,7 @@ test.describe.serial('体重記録 CRUD', () => {
     // 編集モーダルが開いたことを確認する
     await expect(page.getByText('記録を編集')).toBeVisible();
 
-    await page.getByPlaceholder('75.0').fill(UPDATED_WEIGHT);
+    await page.getByPlaceholder('体重 (kg) を入力').fill(UPDATED_WEIGHT);
     await page.getByRole('button', { name: '保存' }).click();
 
     // 更新後の体重が記録一覧に反映されることを確認する

--- a/e2e/bodyRecord.spec.ts
+++ b/e2e/bodyRecord.spec.ts
@@ -22,31 +22,32 @@ test.describe.serial('体重記録 CRUD', () => {
     // モーダルが閉じたことを確認する
     await expect(page.getByPlaceholder('体重 (kg) を入力').first()).not.toBeVisible();
 
-    // revalidatePath後の再レンダリングで記録一覧に体重が表示されることを確認する
-    await expect(page.getByText(`${TEST_WEIGHT} kg`)).toBeVisible();
+    // revalidatePath後の再レンダリングで記録一覧に体重が表示されることを確認する（PC・SPで2要素あるため first()）
+    await expect(page.getByText(`${TEST_WEIGHT} kg`).first()).toBeVisible();
   });
 
   test('体重記録を編集できる', async ({ page }) => {
     // PC・SP で同じレコードに対して2つの編集ボタンが描画されるため first() で取得する
     await page.getByRole('button', { name: '編集' }).first().click();
 
-    // 編集モーダルが開いたことを確認する
-    await expect(page.getByText('記録を編集')).toBeVisible();
+    // 編集モーダルが開いたことを確認する（PC・SPで2要素あるため first()）
+    await expect(page.getByText('記録を編集').first()).toBeVisible();
 
     await page.getByPlaceholder('体重 (kg) を入力').first().fill(UPDATED_WEIGHT);
     await page.getByRole('button', { name: '保存' }).click();
 
-    // 更新後の体重が記録一覧に反映されることを確認する
-    await expect(page.getByText(`${UPDATED_WEIGHT} kg`)).toBeVisible();
+    // モーダルが閉じてからrevalidatePath後の再レンダリングを待つ（PC・SPで2要素あるため first()）
+    await expect(page.getByText('記録を編集').first()).not.toBeVisible();
+    await expect(page.getByText(`${UPDATED_WEIGHT} kg`).first()).toBeVisible();
   });
 
   test('体重記録を削除できる', async ({ page }) => {
-    await expect(page.getByText(`${UPDATED_WEIGHT} kg`)).toBeVisible();
+    await expect(page.getByText(`${UPDATED_WEIGHT} kg`).first()).toBeVisible();
 
     // PC・SP で同じレコードに対して2つの削除ボタンが描画されるため first() で取得する
     await page.getByRole('button', { name: '削除' }).first().click();
 
     // 削除後に対象の記録が一覧から消えることを確認する
-    await expect(page.getByText(`${UPDATED_WEIGHT} kg`)).not.toBeVisible();
+    await expect(page.getByText(`${UPDATED_WEIGHT} kg`).first()).not.toBeVisible();
   });
 });

--- a/e2e/bodyRecord.spec.ts
+++ b/e2e/bodyRecord.spec.ts
@@ -13,14 +13,14 @@ test.describe.serial('体重記録 CRUD', () => {
     // PC左ペインとSP FABの両方に「体重を記録」ボタンが存在するため first() で取得する
     await page.getByRole('button', { name: '体重を記録' }).first().click();
 
-    // 入力欄が表示されたことでモーダルが開いたと判断する
-    await expect(page.getByPlaceholder('体重 (kg) を入力')).toBeVisible();
+    // 入力欄が表示されたことでモーダルが開いたと判断する（PC・SPで2要素あるため first() で取得）
+    await expect(page.getByPlaceholder('体重 (kg) を入力').first()).toBeVisible();
 
-    await page.getByPlaceholder('体重 (kg) を入力').fill(TEST_WEIGHT);
+    await page.getByPlaceholder('体重 (kg) を入力').first().fill(TEST_WEIGHT);
     await page.getByRole('button', { name: '保存' }).click();
 
     // モーダルが閉じたことを確認する
-    await expect(page.getByPlaceholder('体重 (kg) を入力')).not.toBeVisible();
+    await expect(page.getByPlaceholder('体重 (kg) を入力').first()).not.toBeVisible();
 
     // revalidatePath後の再レンダリングで記録一覧に体重が表示されることを確認する
     await expect(page.getByText(`${TEST_WEIGHT} kg`)).toBeVisible();
@@ -33,7 +33,7 @@ test.describe.serial('体重記録 CRUD', () => {
     // 編集モーダルが開いたことを確認する
     await expect(page.getByText('記録を編集')).toBeVisible();
 
-    await page.getByPlaceholder('体重 (kg) を入力').fill(UPDATED_WEIGHT);
+    await page.getByPlaceholder('体重 (kg) を入力').first().fill(UPDATED_WEIGHT);
     await page.getByRole('button', { name: '保存' }).click();
 
     // 更新後の体重が記録一覧に反映されることを確認する

--- a/e2e/flow.spec.ts
+++ b/e2e/flow.spec.ts
@@ -18,24 +18,26 @@ test.describe.serial('目標設定から進捗反映までのフロー', () => {
 
   test('目標体重・目標体脂肪率を設定できる', async ({ page }) => {
     await page.getByRole('button', { name: '目標を設定' }).click();
-    await expect(page.getByPlaceholder('70.0')).toBeVisible();
+    // PC・SPで2要素あるため first() で取得する
+    await expect(page.getByPlaceholder('70.0').first()).toBeVisible();
 
-    await page.getByPlaceholder('70.0').fill(TARGET_WEIGHT);
-    await page.getByPlaceholder('15.0').fill(TARGET_BODY_FAT);
+    await page.getByPlaceholder('70.0').first().fill(TARGET_WEIGHT);
+    await page.getByPlaceholder('15.0').first().fill(TARGET_BODY_FAT);
     await page.getByRole('button', { name: '保存' }).click();
 
-    await expect(page.getByPlaceholder('70.0')).not.toBeVisible();
+    await expect(page.getByPlaceholder('70.0').first()).not.toBeVisible();
   });
 
   test('体重・体脂肪率を記録できる', async ({ page }) => {
     await page.getByRole('button', { name: '体重を記録' }).first().click();
-    await expect(page.getByPlaceholder('75.0')).toBeVisible();
+    // PC・SPで2要素あるため first() で取得する
+    await expect(page.getByPlaceholder('体重 (kg) を入力').first()).toBeVisible();
 
-    await page.getByPlaceholder('75.0').fill(CURRENT_WEIGHT);
-    await page.getByPlaceholder('18.0').fill(CURRENT_BODY_FAT);
+    await page.getByPlaceholder('体重 (kg) を入力').first().fill(CURRENT_WEIGHT);
+    await page.getByPlaceholder('体脂肪率 (%) を入力').first().fill(CURRENT_BODY_FAT);
     await page.getByRole('button', { name: '保存' }).click();
 
-    await expect(page.getByPlaceholder('75.0')).not.toBeVisible();
+    await expect(page.getByPlaceholder('体重 (kg) を入力').first()).not.toBeVisible();
   });
 
   test('ProgressBarに目標までの残り体重・体脂肪率が表示される', async ({ page }) => {

--- a/e2e/goal.spec.ts
+++ b/e2e/goal.spec.ts
@@ -5,12 +5,12 @@ test('目標を設定できる', async ({ page }) => {
 
   await page.getByRole('button', { name: '目標を設定' }).click();
 
-  // 入力欄が表示されたことでモーダルが開いたと判断する
-  await expect(page.getByPlaceholder('70.0')).toBeVisible();
+  // 入力欄が表示されたことでモーダルが開いたと判断する（PC・SPで2要素あるため first() で取得）
+  await expect(page.getByPlaceholder('70.0').first()).toBeVisible();
 
-  await page.getByPlaceholder('70.0').fill('63.0');
+  await page.getByPlaceholder('70.0').first().fill('63.0');
   await page.getByRole('button', { name: '保存' }).click();
 
   // モーダルが閉じたことを確認する
-  await expect(page.getByPlaceholder('70.0')).not.toBeVisible();
+  await expect(page.getByPlaceholder('70.0').first()).not.toBeVisible();
 });


### PR DESCRIPTION
## Summary

- UIリデザインで `RecordModal.tsx` の体重入力フィールドの `placeholder` が `'75.0'` → `'体重 (kg) を入力'` に変わったことによるE2Eテスト失敗を修正

## Test plan

- [ ] E2E `体重記録 CRUD` が全件パスする

🤖 Generated with [Claude Code](https://claude.com/claude-code)